### PR TITLE
Add second algorithm that matches on same names

### DIFF
--- a/test/module_ref/other_tls.tf
+++ b/test/module_ref/other_tls.tf
@@ -1,0 +1,6 @@
+resource "tls_private_key" "example3" {
+  algorithm = "ECDSA"
+}
+resource "tls_private_key" "example2" {
+  algorithm = "ECDSA"
+}

--- a/test/module_ref/ref.tf
+++ b/test/module_ref/ref.tf
@@ -1,3 +1,6 @@
 module "empty_mod" {
   source = "../empty"
 }
+module "another_empty_mod" {
+  source = "../another_empty"
+}

--- a/tfmv.go
+++ b/tfmv.go
@@ -137,12 +137,12 @@ func getMoveStatements(plan *tfmt.Plan, mode string) ([]string, error) {
 }
 
 func main() {
-  planfile := flag.String("plan-file", "tfplan", "name of the plan-file")
+	planfile := flag.String("plan-file", "tfplan", "name of the plan-file")
 	mode := flag.String("mode", "first-matching", "mode to use when matching resources to each other. Can be first-matching or same-name")
 
 	flag.Parse()
 
-  plan, err := getPlan(*planfile)
+	plan, err := getPlan(*planfile)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/tfmv.go
+++ b/tfmv.go
@@ -6,9 +6,13 @@ import (
 	"os"
 	"reflect"
 
+	"flag"
 	tfmt "github.com/hashicorp/terraform/command/format"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+const MatchModeFirstMatching = "first-matching"
+const MatchModeSameName = "same-name"
 
 func getPlan(file string) (fmtPlan *tfmt.Plan, err error) {
 	f, err := os.Open(file)
@@ -48,7 +52,30 @@ func checkIfObjectsMatch(name string, creation, deletion interface{}) error {
 	return nil
 }
 
-func getMoveStatements(plan *tfmt.Plan) ([]string, error) {
+func matchSameName(creation tfmt.InstanceDiff, changes *ResourceChanges) *tfmt.InstanceDiff {
+	for _, destruction := range changes.Destroyed {
+		if creation.Addr.Name == destruction.Addr.Name {
+			return &destruction
+
+		}
+	}
+	return nil
+}
+
+func appendMove(moves []string, creation, deletion tfmt.InstanceDiff) ([]string, error) {
+	// sanity checks
+	if err := checkIfObjectsMatch("Addrs", creation.Addr, deletion.Addr); err != nil {
+		return moves, err
+	}
+	if err := checkIfObjectsMatch("InstanceDiffs", creation, deletion); err != nil {
+		return moves, err
+	}
+
+	moves = append(moves, "terraform state mv "+deletion.Addr.String()+" "+creation.Addr.String())
+	return moves, nil
+}
+
+func getMoveStatementsForFirstMatching(plan *tfmt.Plan) ([]string, error) {
 	moves := []string{}
 
 	changesByType, err := getChangesByType(plan)
@@ -64,30 +91,63 @@ func getMoveStatements(plan *tfmt.Plan) ([]string, error) {
 			}
 			deletion := changes.Destroyed[i]
 
-			// sanity checks
-			if err := checkIfObjectsMatch("Addrs", creation.Addr, deletion.Addr); err != nil {
+			moves, err = appendMove(moves, creation, deletion)
+			if err != nil {
 				return moves, err
 			}
-			if err := checkIfObjectsMatch("InstanceDiffs", creation, deletion); err != nil {
-				return moves, err
-			}
-
-			moves = append(moves, "terraform state mv "+deletion.Addr.String()+" "+creation.Addr.String())
 		}
 	}
 
 	return moves, nil
 }
 
+func getMoveStatementsForSameName(plan *tfmt.Plan) ([]string, error) {
+	moves := []string{}
+
+	changesByType, err := getChangesByType(plan)
+	if err != nil {
+		return moves, err
+	}
+
+	for _, changes := range changesByType {
+		for _, creation := range changes.Created {
+
+			match := matchSameName(creation, changes)
+			if match != nil {
+				if moves, err = appendMove(moves, creation, *match); err != nil {
+					return moves, err
+				}
+
+			}
+		}
+	}
+
+	return moves, nil
+}
+
+func getMoveStatements(plan *tfmt.Plan, mode string) ([]string, error) {
+	switch mode {
+	case MatchModeFirstMatching:
+		return getMoveStatementsForFirstMatching(plan)
+	case MatchModeSameName:
+		return getMoveStatementsForSameName(plan)
+	default:
+		return nil, fmt.Errorf("unknown match-mode %s, available modes are %s (default) and %s", mode, MatchModeFirstMatching, MatchModeSameName)
+	}
+}
+
 func main() {
 	// TODO parameterize
+	mode := flag.String("mode", "first-matching", "mode to use when matching resources to each other. Can be first-matching or same-name")
+
+	flag.Parse()
 	planfile := "tfplan"
 	plan, err := getPlan(planfile)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	moves, err := getMoveStatements(plan)
+	moves, err := getMoveStatements(plan, *mode)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
Thank you for building this @afeld, tfmv has helped me a lot when refactoring terraform code! 

However, when trying to refactor a larger terraform project (setting up lots of IAM permissions) into multiple modules I ran into problems since this change had lots of resources of the same type and reordered a few so the existing algorithm matched the wrong resources.

To improve this, this PR adds a second algorithm that is order-independent but matches on resources with the same name. 
It's obviously useless when renaming resources but very useful and reliable when refactoring into modules so this PR also adds a flag (e.g. `tfmv -mode same-name`) to specify the algorithm to use.

Related to #4 
